### PR TITLE
merge async branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
-version: 2.0
+version: 2.1
 
 # Default actions to perform on each Emacs version
-default: &default-steps
-  steps:
-    - checkout
-    - run: make version
-    - run: make lint
-    - run: make test
+commands:
+  default-steps:
+    steps:
+      - checkout
+      - run: make version
+      - run: make lint
+      - run: make test
 
 # Enumerated list of Emacs versions
 jobs:
@@ -14,25 +15,29 @@ jobs:
     docker:
       - image: silex/emacs:25-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - default-steps
 
   test-emacs-26:
     docker:
       - image: silex/emacs:26-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - default-steps
 
   test-emacs-27:
     docker:
       - image: silex/emacs:27-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - default-steps
 
   test-emacs-master:
     docker:
       - image: silex/emacs:master-dev
         entrypoint: bash
-    <<: *default-steps
+    steps:
+      - default-steps
 
   coverage:
     docker:
@@ -44,7 +49,6 @@ jobs:
 
 # Executing in parallel
 workflows:
-  version: 2
   ci-test-matrix:
     jobs:
       - test-emacs-25

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,2 +1,2 @@
 ((emacs-lisp-mode . ((indent-tabs-mode . nil)
-                     (fill-column . 80))))
+                     (fill-column . 85))))

--- a/.emacs/dependencies.el
+++ b/.emacs/dependencies.el
@@ -9,7 +9,10 @@
 (use-package undercover
   :ensure t)
 
-(use-package request
+(use-package deferred
+  :ensure t)
+
+(use-package request-deferred
   :ensure t)
 
 ;;; dependencies.el ends here

--- a/README.md
+++ b/README.md
@@ -17,16 +17,30 @@ strength of each signal to triangulate your latitude and longitude.
 
 ### Entry points
 
-- `geolocation-get-position` which returns your estimated position as
-  an alist with the following keys:
-  - `lat` - latitude of the current position
-  - `lon` - longitude of the current position
-  - `accuracy` - an error radius, in meters
+- `geolocation-watch-position` which calls `geolocation-get-position`
+  on a regular interval, and sets `geolocation-location` with the
+  result.  Calls the `geolocation-update-hook` functions after each
+  update.  Customize the hook if you want to invoke functions based on
+  your position, and customize the `geolocation-update-interval` with
+  the time granularity you need, keeping in mind the underlying
+  positioning APIs may have rate limits and/or costs associated with
+  high frequency querying.
 
-- `geolocation-scan-wifi` which scans for nearby wifi access points
-  using available system utilites, and produces a complete list of
-  everything in range sorted by signal strength.
-  Returns a list of alists containing:
+  The variable `geolocation-location` will contain nil or an alist:
+    - `latitude` - latitude of the current position
+    - `longitude` - longitude of the current position
+    - `accuracy` - an error radius, in meters
+    - `timestamp` - timestamp via `float-time`
+
+Other potentially useful functions include:
+
+- `geolocation-get-position` which retrieves your estimated position
+  once and invokes a callback with the position data.  The callback
+  receives an alist with the same format as `geolocation-location`.
+
+- `geolocation-scan-wifi` which scans asynchronously for nearby wifi
+  access points using available system utilites, and invokes a callback
+  with the wifi data.  The callback receives a list of alists containing:
   - `bssid` - mac address that uniquely identifies the AP
   - `signal` - relative signal strength, or RSSI
   - `channel` - transmission channel

--- a/geolocation.el
+++ b/geolocation.el
@@ -698,23 +698,26 @@ The result is sent to CALLBACK as an alist with the following keys:
             (geolocation--call-unwiredlabs-api wifi callback))))))
 
 (defun geolocation--update-position (p)
-  "Update `geolocation-location' to position P."
-  (setq geolocation-location p))
-
-;;;###autoload
-(defun geolocation-watch-position ()
-  "Call `geolocation-get-position' on regular intervals.
-Update `geolocation-location' with the discovered position,
-and call the `geolocation-update-hook' functions after updating.
-The interval is controlled by `geolocation-update-interval',
-and if the interval is zero then stop watching."
-  (geolocation-get-position #'geolocation--update-position)
+  "Update `geolocation-location' to position P.
+Then call hooks and queue the next position check."
+  (setq geolocation-location p)
   (dolist (hook geolocation-update-hook)
     (funcall hook))
   (when (> geolocation-update-interval 0)
     (run-at-time geolocation-update-interval
                  nil
                  #'geolocation-watch-position)))
+
+;;;###autoload
+(defun geolocation-watch-position ()
+  "Call `geolocation-get-position' on regular intervals.
+
+This call updates `geolocation-location' with the discovered
+position, and then runs the `geolocation-update-hook' functions
+after updating.  The watch interval is controlled by
+`geolocation-update-interval'.  If interval is zero then stop."
+  ;; TODO: this implementation is too brittle.
+  (geolocation-get-position #'geolocation--update-position))
 
 (provide 'geolocation)
 ;;; geolocation.el ends here

--- a/geolocation.el
+++ b/geolocation.el
@@ -645,23 +645,31 @@ Return a deferred object for chaining further operations."
     (geolocation--linux-scan-wifi callback))))
 
 ;;;###autoload
-(defun geolocation-get-position ()
-  "Return your estimated position in terms of latitude and longitude.
-
-The reply is an alist with at least the following keys:
+(defun geolocation-get-position (&optional callback)
+  "Obtain your estimated position in terms of latitude and longitude.
+The result is sent to CALLBACK as an alist with the following keys:
   `lat'      : latitude of the current position
   `lon'      : longitude of the current position
   `accuracy' : accuracy of the estimate in meters
 
 Other keys may be included in the result, but are not guaranteed
 to be supported going forward."
-  (when-let ((wifi (geolocation-scan-wifi)))
-    (cond ((eq :google geolocation-api-vendor)
-           (geolocation--call-google-api wifi))
-          ((eq :here geolocation-api-vendor)
-           (geolocation--call-here-api wifi))
-          ((eq :unwiredlabs geolocation-api-vendor)
-           (geolocation--call-unwiredlabs-api wifi)))))
+
+  ;; TODO: learn how to dynamically chain deferreds and then
+  ;; we don't have to nest callbacks in this way.
+
+  (geolocation-scan-wifi
+   (lambda (wifi)
+     ;; This lambda is the callback for `-scan-wifi'.
+     ;; it receives the wifi list and forwards it to the
+     ;; selected api vendor.
+     (cond ((eq :google geolocation-api-vendor)
+            (geolocation--call-google-api wifi callback))
+           ((eq :here geolocation-api-vendor)
+            (geolocation--call-here-api wifi callback))
+           ((eq :unwiredlabs geolocation-api-vendor)
+            (geolocation--call-unwiredlabs-api wifi callback))))))
+
 
 (provide 'geolocation)
 ;;; geolocation.el ends here

--- a/geolocation.el
+++ b/geolocation.el
@@ -170,6 +170,11 @@ function is substituted instead."
     (deferred:nextc it parser)
     (deferred:nextc it
       (lambda (x)
+        (sort x (lambda (i j)
+                  (> (alist-get 'signal i)
+                     (alist-get 'signal j))))))
+    (deferred:nextc it
+      (lambda (x)
         (if callback                    ; e.g. to save wifi data
             (funcall callback x)
           x)))
@@ -606,24 +611,16 @@ hostname `geolocation--unwiredlabs-auth-source-host' and username
 ;; Public API
 
 ;;;###autoload
-(defun geolocation-scan-wifi ()
-  "Return a list of nearby wifi access points.
-The result is sorted by signal strength with the strongest first.
-
-Each item in the list is an alist with the following keys:
-  `bssid'   : mac address of the access point
-  `signal'  : relative signal strength or rssi
-  `channel' : broadcast channel"
-  (when-let ((aps (cond
-                   ((string-equal system-type "darwin")
-                    (geolocation--osx-scan-wifi))
-                   ((string-equal system-type "windows-nt")
-                    (geolocation--windows-scan-wifi))
-                   ((string-equal system-type "gnu/linux")
-                    (geolocation--linux-scan-wifi)))))
-    (sort aps (lambda (x y)
-                (> (alist-get 'signal x)
-                   (alist-get 'signal y))))))
+(defun geolocation-scan-wifi (&optional callback)
+  "Scan wifi asynchronously, and optionally call CALLBACK with result.
+Return a deferred object for chaining further operations."
+  (cond
+   ((string-equal system-type "darwin")
+    (geolocation--osx-scan-wifi callback))
+   ((string-equal system-type "windows-nt")
+    (geolocation--windows-scan-wifi callback))
+   ((string-equal system-type "gnu/linux")
+    (geolocation--linux-scan-wifi callback))))
 
 ;;;###autoload
 (defun geolocation-get-position ()

--- a/geolocation.el
+++ b/geolocation.el
@@ -456,10 +456,9 @@ hostname `geolocation-api-google-auth-source-host' and username
        :user geolocation-api-google-auth-source-user)))
 
 (defun geolocation--call-google-api (wd callback)
-  "Make asynch Google API request with wifi data and send to CALLBACK.
-The wifi data will be supplied in a deferred object WD.  The CALLBACK
-is expected to store the resulting location data.  Return the
-deferred object containing the result of CALLBACK.
+  "Request location from Google API using wifi data in the deferred WD.
+Send results to a CALLBACK which is expected to store the
+resulting location data.  Return a deferred object.
 
 The implementation is a chain of deferreds with the following
 steps executing on a separate thread:
@@ -565,10 +564,9 @@ hostname `geolocation-api-here-auth-source-host' and username
        :user geolocation-api-here-auth-source-user)))
 
 (defun geolocation--call-here-api (wd callback)
-  "Make asynch HERE API request with wifi data and send to CALLBACK.
-The wifi data will be supplied in a deferred object WD.  The
-CALLBACK is expected to store the resulting location data.
-Return the deferred object containing the result of CALLBACK.
+  "Request location from HERE API using wifi data in the deferred WD.
+Send results to a CALLBACK which is expected to store the
+resulting location data.  Return a deferred object.
 
 The implementation is a chain of deferreds with the following
 steps executing on a separate thread:
@@ -672,10 +670,9 @@ hostname `geolocation--unwiredlabs-auth-source-host' and username
        :user geolocation-api-unwiredlabs-auth-source-user)))
 
 (defun geolocation--call-unwiredlabs-api (wd callback)
-  "Make asych Unwiredlabs API request with wifi data and send to CALLBACK.
-The wifi data will be supplied in a deferred object WD.  The
-CALLBACK is expected to store the resulting location data.
-Return the deferred onject containing the result of CALLBACK.
+  "Request location from Unwired Labs API using wifi data in the deferred WD.
+Send results to a CALLBACK which is expected to store the
+resulting location data.  Return a deferred object.
 
 The implementation is a chain of deferreds with the following steps
 executing on a separate thread:
@@ -740,8 +737,6 @@ result is sent to CALLBACK as an alist with the following keys:
           ((eq :unwiredlabs geolocation-api-vendor)
            (geolocation--call-unwiredlabs-api wd callback)))))
 
-(defvar geolocation--watch-active nil)
-
 (defun geolocation--update-position-callback (p)
   "Update `geolocation-location' to position P.
 Then call the `geolocation-update-hook' functions."
@@ -749,6 +744,11 @@ Then call the `geolocation-update-hook' functions."
   (message "geolocation-location: %s" geolocation-location)
   (dolist (hook geolocation-update-hook)
     (funcall hook)))
+
+(defvar geolocation--watch-active nil
+  "Control the `geolocation--watch-position-loop' iteration.
+Value of t to continue and nil to stop.  This var is managed by
+`geolocation-watch-position' and need not be set directly.")
 
 (defun geolocation--watch-position-loop ()
   "Call `geolocation-get-position' in a loop.


### PR DESCRIPTION
This branch moves the underlying implementation to use `emacs-deferred` so that the wifi scanning and the API calls to Google/HERE/Unwired Labs are all done in a separate thread.

Resolves #2 by adding a periodic "watch" function and hook functions that will be invoked when the estimated position is updated.